### PR TITLE
pip link fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Pipfile
 
 A ``Pipfile`` is a new (and much better!) way to declare dependencies for your Python environment (e.g. deployment of a web application). It will be a full replacement for the well-pervasive `requirements.txt` files, currently installable with ``$ pip install -r``.
 
-This is a concept project that will eventually be built into [pip](https://github.com/pypa/pip) itself, once the API (including the form of a `Pipfile` itself) has been built out and finalized. 
+This is a concept project that will eventually be built into `pip <https://github.com/pypa/pip>`_ itself, once the API (including the form of a `Pipfile` itself) has been built out and finalized. 
 
 Remember, the important part here is `Pipfile.lock`. It allows deterministic builds. Today's `requirements.txt` can do this, and should, but often doesn't, when version specifiers aren't provided. This efforts will provide a much more pleasant user experience. 
 


### PR DESCRIPTION
The link for pip is currently in markdown syntax instead of restructured text, so it doesn't render correctly.