### PR TITLE
Enable "semantic hashing" of the Pipfile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,9 @@ Notes:
 
     {
         "_meta": {
-            "Pipfile-sha256": "73d81f4fbe42d1da158c5d4435d921121a4a1013b2f0dfed95367f3c742b88c6",
+            "hash": {
+                "sha256": "73d81f4fbe42d1da158c5d4435d921121a4a1013b2f0dfed95367f3c742b88c6",
+            },
             "requires": [
                 {"marker": "python_version", "specifier": "2.7"}
             ],

--- a/pipfile/api.py
+++ b/pipfile/api.py
@@ -128,8 +128,9 @@ class Pipfile(object):
 
     @property
     def hash(self):
-        """Returns the SHA256 of the pipfile."""
-        return hashlib.sha256(self.contents.encode('utf-8')).hexdigest()
+        """Returns the SHA256 of the pipfile's data."""
+        content = json.dumps(self.data, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(content.encode("utf8")).hexdigest()
 
     @property
     def contents(self):
@@ -140,7 +141,8 @@ class Pipfile(object):
     def lock(self):
         """Returns a JSON representation of the Pipfile."""
         data = self.data
-        data['_meta']['Pipfile-sha256'] = self.hash
+        data['_meta']['hash'] = {"sha256": self.hash}
+        # return _json.dumps(data)
         return json.dumps(data, indent=4, separators=(',', ': '))
 
     def assert_requirements(self):


### PR DESCRIPTION
Instead of hashing the actual bytes of the ``Pipfile`` instance, parse it first and then serialize that parsed instance into a canonical format before hashing. This will make it so things like adding comments, whitespace, re-arranging table keys, and other changes that don't alter the *semantics* of the ``Pipfile`` do not invalidate a ``Pipfile.lock``.