### PR TITLE
[WIP] Refactor the pipfile API into a functional one

### DIFF
--- a/examples/Pipfile
+++ b/examples/Pipfile
@@ -8,7 +8,7 @@ python_version = '2.7'
 [packages]
 requests = { extras = ['socks'] }
 Django = '>1.10'
-pinax = { git = 'git://github.com/pinax/pinax.git', ref = '1.4', editable = true }
+# pinax = { git = 'git://github.com/pinax/pinax.git', ref = '1.4', editable = true }
 
 [dev-packages]
 nose = '*'

--- a/examples/Pipfile.lock
+++ b/examples/Pipfile.lock
@@ -1,39 +1,28 @@
 {
-    "default": {
-        "PySocks": {
-            "version": "==1.6.5",
-            "hash": "sha256:7962f4d7c76e8414ae168c677a77f19cf8926143911f7e8d37a5d4c4eb910c6f"
-        },
-        "requests": {
-            "version": "==2.13.0",
-            "hash": "sha256:1a720e8862a41aa22e339373b526f508ef0c8988baf48b84d3fc891a8e237efb"
-        },
-        "Django": {
-            "version": "==1.10.5",
-            "hash": "sha256:4541a60834f28f308ee7b6e96400feca905fb0de473eb9dad6847e98a36d86d4"
-        },
-        "pinax": {
-            "ref": "1.4",
-            "git": "git://github.com/pinax/pinax.git",
-            "editable": true
-        }
+    "digests": {
+        "sha256": "dd1ccbc394626106aa55c112d84a293aba5928cfae3c24098715344251dd2b55"
     },
-    "develop": {
-        "nose": {
-            "version": "==1.3.7",
-            "hash": "sha256:dadcddc0aefbf99eea214e0f1232b94f2fa9bd98fa8353711dacb112bfcbbb2a"
+    "sources": [
+        {
+            "url": "https://pypi.python.org/simple",
+            "verify_ssl": true
         }
-    },
-    "_meta": {
-        "sources": [
-            {
-                "url": "https://pypi.python.org/simple",
-                "verify_ssl": true
-            }
-        ],
-        "requires": {
-            "python_version": "2.7"
+    ],
+    "packages": [
+        {
+            "extras": [
+                "socks"
+            ],
+            "name": "requests"
         },
-        "Pipfile-sha256": "f7b3cb170ff903cb7d269195dd0a8212d335f3d5b7d6f907246fd580c46cf847"
-    }
+        {
+            "name": "Django",
+            "version": ">1.10"
+        }
+    ],
+    "dev-packages": [
+        {
+            "name": "nose"
+        }
+    ]
 }

--- a/pipfile/__init__.py
+++ b/pipfile/__init__.py
@@ -8,4 +8,12 @@ from .__about__ import (
     __uri__, __version__
 )
 
-from .api import load, Pipfile
+from ._api import load, loads, dump, dumps, find, save
+
+
+__all__ = [
+    "__author__", "__copyright__", "__email__", "__license__", "__summary__",
+    "__title__", "__uri__", "__version__",
+
+    "load", "loads", "dump", "dumps", "find", "save",
+]

--- a/pipfile/_api.py
+++ b/pipfile/_api.py
@@ -1,0 +1,134 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import collections
+import json
+import os.path
+
+import toml
+
+from ._structures import Pipfile, PipfileLock
+
+
+def _load_package(package, data):
+    d = {}
+
+    if isinstance(data, str):
+        if data != "*":
+            d["version"] = data
+    else:
+        d.update(data)
+
+    # We put this last, because we don't want to allow a name field in the
+    # actual data set to override the left most name.
+    d["name"] = package
+
+    return d
+
+
+def _dump_package(package):
+    name = package.pop("name")
+
+    if len(package) == 1 and "version" in package:
+        package = package["version"]
+    elif not package:
+        package = "*"
+
+    return name, package
+
+
+def loads(pipfile, lockfile=None):
+    pipfile_data = {}
+    for key, value in toml.loads(pipfile).items():
+        if key == "source":
+            pipfile_data["sources"] = value
+        elif key == "packages":
+            pipfile_data.setdefault("packages", {})["default"] = [_load_package(k, v) for k, v in value.items()]
+        elif key == "dev-packages":
+            pipfile_data.setdefault("packages", {})["development"] = [_load_package(k, v) for k, v in value.items()]
+        elif key == "requires":
+            pass
+        else:
+            raise ValueError("Unknown key {0!r}".format(key))
+
+    pipfile_obj = Pipfile.create(pipfile_data)
+
+    if lockfile is not None:
+        lockfile_obj = PipfileLock.create(json.loads(lockfile))
+    else:
+        lockfile_obj = None
+
+    return pipfile_obj, lockfile_obj
+
+
+def load(pipfile_obj, lockfile_obj=None):
+    return loads(
+        pipfile_obj.read(),
+        lockfile_obj.read() if lockfile_obj is not None else None,
+    )
+
+
+def dumps(obj):
+    if isinstance(obj, Pipfile):
+        data = collections.OrderedDict([
+            ("source", obj.sources.serialize()),
+            ("packages", dict(_dump_package(p) for p in obj.packages["default"].serialize())),
+            ("dev-packages", dict(_dump_package(p) for p in obj.packages["development"].serialize())),
+        ])
+        return toml.dumps(data)
+    elif isinstance(obj, PipfileLock):
+        data = collections.OrderedDict([
+            ("digests", obj.digests.serialize()),
+            ("sources", obj.sources.serialize()),
+            ("packages", obj.packages["default"].serialize()),
+            ("dev-packages", obj.packages["development"].serialize()),
+        ])
+        return json.dumps(data, indent=4, separators=(",", ": "))
+    else:
+        raise ValueError("Unknown object type: {0!r}".format(obj.__class__))
+
+
+def dump(file_obj, data):
+    file_obj.write(dumps(data))
+
+
+def find(root="."):
+    # TODO: Use walk_up or something to actually recursively look upwards from
+    #       the root directory instead of *only* looking in the root directory.
+    # TODO: Also look for pipfile, Pipfile.toml, and pipfile.toml, in that
+    #       order of preferece.
+    pipfile_path = os.path.join(root, "Pipfile")
+    if not os.path.exists(pipfile_path):
+        return None, None
+
+    with open(pipfile_path, "r", encoding="utf8") as pfp:
+        # TODO: Also look for pipfile.lock.
+        lockfile_path = os.path.join(
+            os.path.dirname(pipfile_path),
+            "Pipfile.lock",
+        )
+        if os.path.exists(lockfile_path):
+            with open(lockfile_path, "r", encoding="utf8") as lfp:
+                return load(pfp, lfp)
+        else:
+            return load(pfp)
+
+
+def save(pipfile, pipfilelock=None, remove_stale=True, root="."):
+    # TODO: Again we'd use walk_up or something here to attempt to recursively
+    #       locate the files that we're going to be over-writing. Except this
+    #       time if we couldn't find a file to replace, we'll just write new
+    #       files in the root directory.
+    pipfile_path = os.path.join(root, "Pipfile")
+    lockfile_path = os.path.join(root, "Pipfile.lock")
+
+    with open(pipfile_path, "w", encoding="utf8") as pfp:
+        dump(pfp, pipfile)
+
+    if pipfilelock is not None:
+        with open(lockfile_path, "w", encoding="utf8") as lfp:
+            dump(lfp, pipfilelock)
+    elif remove_stale and os.path.exists(lockfile_path):
+        os.remove(lockfile_path)

--- a/pipfile/_structures.py
+++ b/pipfile/_structures.py
@@ -1,0 +1,117 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+from __future__ import absolute_import, division, print_function
+
+import hashlib
+import json
+
+import pyrsistent
+
+
+class Source(pyrsistent.PRecord):
+
+    url = pyrsistent.field(type=str, mandatory=True)
+    verify_ssl = pyrsistent.field(type=bool, initial=True, mandatory=True)
+
+
+class Sources(pyrsistent.CheckedPVector):
+
+    __type__ = Source
+
+
+class Extras(pyrsistent.CheckedPVector):
+
+    __type__ = str  # TODO: A better type for an Extra Name, or at least an invariant.
+
+
+class Requirement(pyrsistent.PRecord):
+
+    name = pyrsistent.field(type=str, mandatory=True)  # TODO: Invarient from packaging.
+    version = pyrsistent.field(type=str)  # TODO: Invariant + factory for PEP 440 specifier
+    extras = pyrsistent.field(type=Extras)
+
+    # TODO: We need to handle things like git, urls, paths, etc.
+
+
+class Requirements(pyrsistent.CheckedPVector):
+
+    __type__ = Requirement
+
+
+class Packages(pyrsistent.CheckedPMap):
+
+    __key_type__ = str
+    __value_type__ = Requirements
+
+    def __invariant__(key, value):
+        return (
+            key in {"default", "development"},
+            "Key must be one of 'default' or 'development'",
+        )
+
+
+class Pipfile(pyrsistent.PClass):
+
+    sources = pyrsistent.field(type=Sources)
+    packages = pyrsistent.field(type=Packages)
+
+    # TODO: Handle PEP 508 environment markers
+
+    def digests(self):
+        # We need to compute the data in this Pipfile down into a hash
+        # digest, this will ensure that we can detect the difference\
+        # between two different Pipfiles based upon their *semantic*
+        # differences not their byte differences.
+
+        # First, we need to boil our Pipfile data down into something we
+        # can hash, this is easy enough to do by just serializing it and
+        # then dumping it to JSON in a deterministic way.
+        content = json.dumps(
+            self.serialize(),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf8")
+
+        # Now, we loop over our supported hashes, and we ensure that we
+        # have a hash for all of them.
+        digests = {
+            hash_name: hashlib.new(hash_name, content).hexdigest().lower()
+            for hash_name in {"sha256"}
+        }
+
+        # Finally, we turn it into a Digests object and we return it.
+        return Digests.create(digests)
+
+    def lock(self, *, sources, packages):
+        # We need to compute the data in this Pipfile down into a hash digest,
+        # this will ensure that our Pipfile.lock
+
+        return PipfileLock.create({
+            "digests": self.digests(),
+            "sources": sources,
+            "packages": packages,
+        })
+
+
+class Digests(pyrsistent.CheckedPMap):
+
+    __key_type__ = str
+    __value_type__ = str
+
+    def __invariant__(key, value):
+        return (
+            key in {"sha256"},  # TODO: Do we *only* want to support sha256?
+            "Key must be 'sha256'",
+        )
+
+
+class PipfileLock(pyrsistent.PClass):
+
+    digests = pyrsistent.field(
+        type=Digests,
+        mandatory=True,
+        invariant=lambda d: (len(d) > 0, "No digests"),
+    )
+    sources = pyrsistent.field(type=Sources)
+    packages = pyrsistent.field(type=Packages)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     author=about["__author__"],
     author_email=about["__email__"],
 
-    install_requires=['toml'],
+    install_requires=['toml', "pyrsistent"],
 
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This is a WIP, it does not currently actually do all of the things that it would need to do and some of the things it currently does are just flat out wrong. However, it's close enough that it gives a reasonable idea (I think) of what the API and usage would be.

The core idea here is that we have two objects, ``Pipfile`` and ``PipfileLock`` and these two objects are completely immutable. This makes it a *ton* easier to reason about in code (because nothing can ever change the object out from underneath you) and I think it's a good direction for these packaging libraries to head towards in general.

You don't directly create these objects in the public API, instead you're given a few functions that will parse either a ``Pipfile`` or a ``Pipfile.lock`` and give you back already created instances of them. In the case that you want to modify them you simply use the pyristant transformers API or the evolvers API and you can safely do that without having to worry about who else might hold a reference to that object. In addition, ``Pipfile`` objects have a ``lock()`` method which allow you to create a ``PipfileLock`` object given an existing ``Pipfile`` and a resolved set of sources and packages.

Basically, an example of what this API would look like in use is:

```python
import pipfile


# Load our Pipfile and our Pipfile.lock from the examples directory, if the
# Pipfile.lock does not exist, it will be a `None`.
p, pl = pipfile.find("examples/")


if pl is not None or p.digests() != pl.digests:
    # In this case we need to do something to resolve the entire dependeny tree
    # since we do not have an existing lockfile or that lockfile is stale, this
    # also gives us a chance to provide any sources that may not be baked into
    # the Pipfile but that should be baked into the Pipfile.lock.

    # In this example, we'll just reuse the sources given to us in the Pipfile.
    sources = p.sources

    # This is where we might resolve our dependencies, against since this is
    # just an example, we're going to just mirror what was given to us in the
    # Pipfile.
    # Note: This is actually wrong, since it should be pinning exact versions
    #       here. Ideally we would have an invariant that would protect against
    #       what we're doing here, but for now this is a good enough demo.
    packages = p.packages

    # Actually generate our lockfile, this is done by calling the Pipfile.lock()
    # method, which will ensure that we populate the lock file with computed
    # data such as the digests automatically.
    pl = p.lock(sources=sources, packages=packages)


# Here is where a hypothetical project could then consume the now created
# lockfile to actually do the install of the projects that we need.
do_the_install(pl)


# Now that the install is done, we can either exit, or if we were supposed to
# write out our files we could go ahead and do that as well. In this example
# we will rewrite out the files to where they need to go.
pipfile.save(p, pl, root="examples/")

```

While this PR currently does handle reading and saving files (and this works well enough for the lock files) it needs to get a lot better at how it handles the saving out a TOML file. In particular, it currently just completely overwrites the existing TOML file which blows away any comments and possibly changes the formatting of the file itself. This is largely a shortcoming of the TOML library that we're using, but ideally we'd be able to pass in an existing file to ``dumps()`` in the case of attempting to dump a ``Pipfile`` and it would instead merge our changes into that file instead of overwriting it. This merging could happen automatically in the case of ``pipfile.save()``.

Here are a few things to think about in terms of this PR:

* Currently we have a singular set of functions like ``dumps()``, ``dump()``, ``loads()``, and ``load()`` that handle both ``Pipfile`` and ``Pipfile.lock``. In the case of the load functions it asks for the ``Pipfile`` and optionally you can pass in a ``Pipfile.lock`` if they exist, but the dump functions it only accepts one at a time, either a ``Pipfile`` or a ``PipfileLock``. Should we instead have separate functions for loading/dumping a ``Pipfile`` and a ``PipfileLock``?
* The ``pipfile.save()`` function will (eventually) re-do the recursive search up for ``Pipfile`` and ``Pipfile.lock``, and failing to find one it will just save them in the root directory (defaults to ``.``).  This does cause a race condition where someone could place a ``Pipfile`` in the directory tree between the root directory and where we originally loaded the files from. If this is a case that we care about, then perhaps the ideal thing to do is include the file path that we actually loaded the files from in the ``pipfile.find()`` API.
  * One problem with this is the ``Pipfile`` and ``PipfileLock`` objects are intentionally completely divorced from any sort of filesystem or even filesystem representation so we can't just attach the filenames/locations we loaded them from to those objects themselves, we could return it as another value in the tuple returned by ``pipfile.find()``, however we need to either return a single value which is the directory we loaded them from (and we possibly get the same race condition if someone writes a ``Pipfile`` after we read from a ``pipfile``... though I don't think this is a case we need to care about) or we need to return 2 additional values that point to the specific files which starts to get a lot more unwieldy. Personally I would just change the ``pipfile.find()`` API to return ``(directory, Pipfile, PipfileLock or None)``.
* We currently do not do the digest checking for a stale ``Pipfile.lock`` file, leaving that up to the calling project. I *think* that this is the right thing to do, because different projects may want to do different things with it (for example, some may want to just install from the lockfile anyways, or some might want to ignore it and regenerate the lockfile). I could also see a use case for the same project to do different things depending on it's configuration.
* Given ``Pipfile`` and ``PipfileLock`` are immutable, modifying them requires using the pyrisistent transformers API. This is a powerful API that allows a lot of flexibility in modifying an immutable object, you can see below for an example of modifying a ``Pipfile`` object. This is a bit more work than just using mutable objects, but there are nice benefits to using immutable objects, and *generally* the primary unit of work is going to be taking an existing ``Pipfile``, resolving it's dependencies, and then writing it out to a ``Pipfile.lock`` (aka, what ``Pipfile.lock()`` does). If there are other things that are common we can also add additional shortcuts to them as well.

```python
import re

import pipfile
from pipfile._structures import Requirement
from pyrsistent import ny, rex

p, pl = pipfile.find("examples/")

# Let's modify the source, say to rewrite it from using legacy PyPI to using
# Warehouse instead.
# Note, the original p is *not* modified, we only get the new value as `p`
# because we're assigning it again. If anything else held a reference to the
# original `p` they would still hold it and it would not be modified.
p = p.transform(
    # This translates to doing p.sources[ANY]["url"], it is defining a "path"
    # to traverse down the object to find the thing you want to modify.
    ["sources", ny, "url"],
    # This defines the action, since we're just passing in a function here, it
    # will be called with the value and the return value will be set.
    lambda u: u if not re.search(r"^https?://pypi\.python\.org/simple/?$", u) else "https://pypi.org/simple/",
)

# Let's say we want to add a new dependency as well, we can go ahead and do
# that too.
# TODO: In doing this I discovered this case is kind of crummy and requires
#       importing from a private module. I assuming that appending a new
#       source will too. We should probably add some kind of shortcut to doing
#       this to make it easier. Possibly something like
#        Pipfile().packages["default"].add_project()?
p = p.transform(
    ["packages", "default"],
    p.packages["default"].append(Requirement.create({"name": "foobar"})),
)
```

That is a whole lot of words. I want to see what others think before I push too much further down this path, but overall I think this creates a pretty decent setup that gives nice, immutable objects while also providing good convenience APIs.