### PR TITLE
Use syntax highlighting supported by GitHub and Sphinx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Examples
 ``Pipfile``
 +++++++++++
 
-::
+.. code-block:: toml
 
     [[source]]
     url = 'https://pypi.python.org/simple'
@@ -65,7 +65,7 @@ Notes:
 **PEP 508 Support** 
 +++++++++++++++++++
 
-::
+.. code-block:: toml
 
     # Support for all PEP 508 markers
     [requires]
@@ -80,7 +80,7 @@ Notes:
 ``Pipfile.lock``
 ++++++++++++++++
 
-::
+.. code-block:: json
 
     {
         "_meta": {


### PR DESCRIPTION
Hi, I added TOML and JSON highlight language with code-block directive.

They are supported by GitHub and Sphinx. Also, the concept of `Pipfile` is also easy to communicate.

For example) 
![highlighting-sample](https://cloud.githubusercontent.com/assets/221802/25580329/26f18ac6-2ebb-11e7-908a-ef45ed7fc119.png)
