### PR TITLE
Example of dependency definition for both default and dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,12 +57,13 @@ Here is a complex, comprehensive example ``Pipfile`` and the resulting ``Pipfile
     [packages]
     requests = { extras = ['socks'] }
     records = '>0.5.0'
-    django = { git = 'https://github.com/django/django.git', ref = '1.11.4', editable = true }
+    django = "*"
     "e682b37" = {file = "https://github.com/divio/django-cms/archive/release/3.4.x.zip"}
     "e1839a8" = {path = ".", editable = true}
     pywinusb = { version = "*", os_name = "=='nt'", index="pypi"}
 
     [dev-packages]
+    django = { git = 'https://github.com/django/django.git', ref = '1.11.4', editable = true }
     nose = '*'
     unittest2 = {version = ">=1.0,<3.0", markers="python_version < '2.7.9' or (python_version >= '3.0' and python_version < '3.4')"}
 


### PR DESCRIPTION
Adding the example given in #91 by @kennethreitz 

I originally wanted to move `"e1839a8" = {path = ".", editable = true}` to the dev section, and adding the "real package dependency" in the default section, but I'm not sure how to make it clear those 2 are linked, so I skipped it for now. If someone has an idea for this one, go ahead.