### PR TITLE
Allow usage of Environment Variables inside TOML values

### DIFF
--- a/pipfile/api.py
+++ b/pipfile/api.py
@@ -69,7 +69,6 @@ class PipfileParser(object):
         parsed_toml = self.inject_environment_variables(toml.loads(content))
 
         # Load the Pipfile's configuration.
-        config.update(toml.loads(content))
         config.update(parsed_toml)
 
         # Structure the data for output.

--- a/pipfile/api.py
+++ b/pipfile/api.py
@@ -31,6 +31,24 @@ class PipfileParser(object):
     def __repr__(self):
         return '<PipfileParser path={0!r}'.format(self.filename)
 
+    def inject_environment_variables(self, d):
+        """
+        Recursively injects environment variables into TOML values
+        """
+
+        if not d:
+            return d
+
+        for k, v in d.items():
+            if isinstance(v, str):
+                d[k] = os.path.expandvars(v)
+            elif isinstance(v, dict):
+                d[k] = self.inject_environment_variables(v)
+            elif isinstance(v, list):
+                d[k] = [self.inject_environment_variables(e) for e in v]
+
+        return d
+
     def parse(self):
         # Open the Pipfile.
         with open(self.filename) as f:
@@ -47,8 +65,12 @@ class PipfileParser(object):
         config = {}
         config.update(default_config)
 
+        # Deserialize the TOML, and parse for Environment Variables
+        parsed_toml = self.inject_environment_variables(toml.loads(content))
+
         # Load the Pipfile's configuration.
         config.update(toml.loads(content))
+        config.update(parsed_toml)
 
         # Structure the data for output.
         data = {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,52 @@
+import json
+import os
+from unittest import TestCase, mock
+
+from pipfile.api import PipfileParser
+
+
+class TestEnvVarInsertion(TestCase):
+
+    def setUp(self):
+        self.p = PipfileParser()
+
+    @staticmethod
+    def example_dict(key):
+        return {
+            "a_string": "https://$%s@something.com" % key,
+            "another_string": "https://${%s}@something.com" % key,
+            "nested": {
+                "a_string": "https://$%s@something.com" % key,
+                "another_string": "${%s}" % key,
+            },
+            "list": [
+                {
+                    "a_string": "https://$%s@something.com" % key,
+                    "another_string": "${%s}" % key,
+                },
+                {},
+            ],
+            "bool": True,
+            "none": None,
+        }
+
+    @mock.patch.dict(os.environ, {'FOO': 'BAR'})
+    def test_correctly_inserts_env_vars(self):
+        parsed_dict = self.p.inject_environment_variables(self.example_dict('FOO'))
+
+        self.assertEqual(parsed_dict["a_string"], "https://BAR@something.com")
+        self.assertEqual(parsed_dict["another_string"], "https://BAR@something.com")
+        self.assertEqual(parsed_dict["nested"]["another_string"], "BAR")
+        self.assertEqual(parsed_dict["list"][0]["a_string"], "https://BAR@something.com")
+        self.assertEqual(parsed_dict["list"][1], {})
+        self.assertTrue(parsed_dict["bool"])
+        self.assertIsNone(parsed_dict["none"])
+
+    @mock.patch.dict(os.environ, {})
+    def test_leaves_values_intact_if_no_var_exists(self):
+        d = self.example_dict('FOO')
+
+        raw = json.dumps(d)
+        parsed = json.dumps(self.p.inject_environment_variables(d))
+
+        self.assertEqual(raw, parsed)


### PR DESCRIPTION
We're relying on `os.path.expandvars()` to inject environment variables in values. 

- Please see Issue https://github.com/pypa/pipenv/issues/1688 for context
- This is the source for PR https://github.com/pypa/pipenv/pull/1769

Some thoughts:

- The `Pipfile` hash should be determined *after* values have attempted to be inserted.
- `Pipfile` shouldn't be intelligent by trying to differentiate env vars from regular characters—if an env var can't be inserted, the string should remain intact.
- As it stands, `Pipenv`'s `vendor` folder contains some version of this repository. I don't fully understand the reasons behind this, couldn't we pin it as a requirement instead? We could then separate tests.
