### PR TITLE
Fix envrionment variable expansion on str types

### DIFF
--- a/pipfile/api.py
+++ b/pipfile/api.py
@@ -4,6 +4,7 @@ import codecs
 import json
 import hashlib
 import platform
+import six
 import sys
 import os
 
@@ -38,9 +39,10 @@ class PipfileParser(object):
 
         if not d:
             return d
-
+        if isinstance(d, six.string_types):
+            return os.path.expandvars(d)
         for k, v in d.items():
-            if isinstance(v, str):
+            if isinstance(v, six.string_types):
                 d[k] = os.path.expandvars(v)
             elif isinstance(v, dict):
                 d[k] = self.inject_environment_variables(v)


### PR DESCRIPTION
Upstreaming of pypa/pipenv#1809: "Fix environment variable expansion with extras"

Fixes #106.

cc @techalchemy 