### PR TITLE
Fit Python 3.10 version string

### DIFF
--- a/pipfile/api.py
+++ b/pipfile/api.py
@@ -155,7 +155,7 @@ class Pipfile(object):
             'platform_release': platform.release(),
             'platform_system': platform.system(),
             'platform_version': platform.version(),
-            'python_version': platform.python_version()[:3],
+            'python_version': '.'.join(platform.python_version_tuple()[:2]),
             'python_full_version': platform.python_version(),
             'implementation_name': implementation_name,
             'implementation_version': implementation_version


### PR DESCRIPTION
Fix truncation of '3.10' version string.

This produces the expected major.minor version string on 2.7, and 3.4 through 3.10.