### PR TITLE
More honest language in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Pipfile: the replacement for `requirements.txt`
+Pipfile: a proposed replacement for `requirements.txt`
 ===============================================
 
 ``Pipfile`` and its sister ``Pipfile.lock`` are designed as a proposed replacement for an existing format: `pip`_'s ``requirements.txt`` file.
@@ -436,9 +436,7 @@ Inspirations
 Documentation
 -------------
 
-The `documentation`_ for this project will, eventually, reside at pypi.org.
-
-.. _`documentation`: https://pipfile.pypa.io/
+The documentation for this project can be found at https://pipfile.pypa.io/
 
 
 Discussion


### PR DESCRIPTION
I believe that (in spite of #138) the language in this repository's `README.md` is, I will say, dishonest and self-aggrandising, in favour of the project's (past) author/s.

I've simply happened across this repository because I am looking to parse `Pipfile`s. I am not involved in the development of Python, any PyPA activities / projects, or any Python packaging projects of any sort. Thus, my assertion that the README's language is inaccurate may be based on a misunderstanding on my part. However as a layperson 'consumer' of Python, I believe that concise language, especially for anything related to Python packaging, especially anything (now) under the PyPA umbrella, is really important.